### PR TITLE
Optimize endpoint blacklist

### DIFF
--- a/howfast_apm/flask.py
+++ b/howfast_apm/flask.py
@@ -4,8 +4,6 @@ from datetime import datetime, timezone
 from timeit import default_timer as timer
 from flask.signals import request_started
 from flask import Flask, request
-import re
-import fnmatch
 
 from .core import CoreAPM
 from .utils import is_in_blacklist, convert_endpoints

--- a/howfast_apm/flask.py
+++ b/howfast_apm/flask.py
@@ -6,7 +6,7 @@ from flask.signals import request_started
 from flask import Flask, request
 
 from .core import CoreAPM
-from .utils import is_in_blacklist, convert_endpoints
+from .utils import is_in_blacklist, compile_endpoints
 
 logger = logging.getLogger('howfast_apm')
 
@@ -42,7 +42,7 @@ class HowFastFlaskMiddleware(CoreAPM):
         app.wsgi_app = self
 
         if endpoints_blacklist:
-            self.endpoints_blacklist = convert_endpoints(*endpoints_blacklist)
+            self.endpoints_blacklist = compile_endpoints(*endpoints_blacklist)
         else:
             self.endpoints_blacklist = []
 

--- a/howfast_apm/flask.py
+++ b/howfast_apm/flask.py
@@ -4,9 +4,11 @@ from datetime import datetime, timezone
 from timeit import default_timer as timer
 from flask.signals import request_started
 from flask import Flask, request
+import re
+import fnmatch
 
 from .core import CoreAPM
-from .utils import is_in_blacklist
+from .utils import is_in_blacklist, convert_endpoints
 
 logger = logging.getLogger('howfast_apm')
 
@@ -42,7 +44,7 @@ class HowFastFlaskMiddleware(CoreAPM):
         app.wsgi_app = self
 
         if endpoints_blacklist:
-            self.endpoints_blacklist = endpoints_blacklist
+            self.endpoints_blacklist = convert_endpoints(*endpoints_blacklist)
         else:
             self.endpoints_blacklist = []
 

--- a/howfast_apm/utils.py
+++ b/howfast_apm/utils.py
@@ -5,6 +5,7 @@ from typing import List
 
 
 def convert_endpoints(*blacklist):
+    """Compiles a list endpoints to a list of regexes"""
     return [re.compile(fnmatch.translate(x)) for x in blacklist]
 
 

--- a/howfast_apm/utils.py
+++ b/howfast_apm/utils.py
@@ -4,7 +4,7 @@ import re
 from typing import List
 
 
-def convert_endpoints(*blacklist):
+def compile_endpoints(*blacklist):
     """Compiles a list endpoints to a list of regexes"""
     return [re.compile(fnmatch.translate(x)) for x in blacklist]
 
@@ -13,11 +13,11 @@ def is_in_blacklist(uri: str, blacklist: List[str]) -> bool:
     """
     Return True if the URI is blacklisted.
 
-      >>> is_in_blacklist('/some-real-uri/', convert_endpoints('/exact-uri/'))
+      >>> is_in_blacklist('/some-real-uri/', compile_endpoints('/exact-uri/'))
       False
-      >>> is_in_blacklist('/exact-uri/', convert_endpoints('/exact-uri/'))
+      >>> is_in_blacklist('/exact-uri/', compile_endpoints('/exact-uri/'))
       True
-      >>> is_in_blacklist('/job/42/retry', convert_endpoints('/job/*'))
+      >>> is_in_blacklist('/job/42/retry', compile_endpoints('/job/*'))
       True
 
     """

--- a/howfast_apm/utils.py
+++ b/howfast_apm/utils.py
@@ -1,22 +1,27 @@
 import fnmatch
+import re
 
 from typing import List
+
+
+def convert_endpoints(*blacklist):
+    return [re.compile(fnmatch.translate(x)) for x in blacklist]
 
 
 def is_in_blacklist(uri: str, blacklist: List[str]) -> bool:
     """
     Return True if the URI is blacklisted.
 
-      >>> is_in_blacklist('/some-real-uri/', ['/exact-uri/'])
+      >>> is_in_blacklist('/some-real-uri/', convert_endpoints('/exact-uri/'))
       False
-      >>> is_in_blacklist('/exact-uri/', ['/exact-uri/'])
+      >>> is_in_blacklist('/exact-uri/', convert_endpoints('/exact-uri/'))
       True
-      >>> is_in_blacklist('/job/42/retry', ['/job/*'])
+      >>> is_in_blacklist('/job/42/retry', convert_endpoints('/job/*'))
       True
 
     """
     for pattern in blacklist:
-        if fnmatch.fnmatch(uri, pattern):
+        if pattern.match(uri):
             return True
     return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,14 +3,16 @@ from howfast_apm import utils
 
 def test_is_blacklist_exact():
     """ The blacklist util should support exact strings matching """
-    assert utils.is_in_blacklist('/some-real-uri/', ['/exact-uri/']) is False
-    assert utils.is_in_blacklist('/exact-uri/', ['/exact-uri/']) is True
-    assert utils.is_in_blacklist('/exact-uri/with-subpath', ['/exact-uri/']) is False
+    blacklist = ['/exact-uri/']
+    assert utils.is_in_blacklist('/some-real-uri/', blacklist) is False
+    assert utils.is_in_blacklist('/exact-uri/', blacklist) is True
+    assert utils.is_in_blacklist('/exact-uri/with-subpath', blacklist) is False
 
     # With multiple patterns
-    assert utils.is_in_blacklist('/exact-uri-1/', ['/exact-uri-1/', '/exact-uri-2/']) is True
-    assert utils.is_in_blacklist('/exact-uri-2/', ['/exact-uri-1/', '/exact-uri-2/']) is True
-    assert utils.is_in_blacklist('/exact-uri-3/', ['/exact-uri-1/', '/exact-uri-2/']) is False
+    multiple_blacklist = ['/exact-uri-1/', '/exact-uri-2/']
+    assert utils.is_in_blacklist('/exact-uri-1/', multiple_blacklist) is True
+    assert utils.is_in_blacklist('/exact-uri-2/', multiple_blacklist) is True
+    assert utils.is_in_blacklist('/exact-uri-3/', multiple_blacklist) is False
 
 
 def test_is_blacklist_glob():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,27 +1,27 @@
-from howfast_apm import utils
+from howfast_apm.utils import convert_endpoints, is_in_blacklist
 
 
 def test_is_blacklist_exact():
     """ The blacklist util should support exact strings matching """
-    blacklist = ['/exact-uri/']
-    assert utils.is_in_blacklist('/some-real-uri/', blacklist) is False
-    assert utils.is_in_blacklist('/exact-uri/', blacklist) is True
-    assert utils.is_in_blacklist('/exact-uri/with-subpath', blacklist) is False
+    blacklist = convert_endpoints('/exact-uri/')
+    assert is_in_blacklist('/some-real-uri/', blacklist) is False
+    assert is_in_blacklist('/exact-uri/', blacklist) is True
+    assert is_in_blacklist('/exact-uri/with-subpath', blacklist) is False
 
     # With multiple patterns
-    multiple_blacklist = ['/exact-uri-1/', '/exact-uri-2/']
-    assert utils.is_in_blacklist('/exact-uri-1/', multiple_blacklist) is True
-    assert utils.is_in_blacklist('/exact-uri-2/', multiple_blacklist) is True
-    assert utils.is_in_blacklist('/exact-uri-3/', multiple_blacklist) is False
+    multiple_blacklist = convert_endpoints('/exact-uri-1/', '/exact-uri-2/')
+    assert is_in_blacklist('/exact-uri-1/', multiple_blacklist) is True
+    assert is_in_blacklist('/exact-uri-2/', multiple_blacklist) is True
+    assert is_in_blacklist('/exact-uri-3/', multiple_blacklist) is False
 
 
 def test_is_blacklist_glob():
     """ The blacklist util should support shell-like matching """
-    blacklist = ['/jobs/*/results', '/support/*']
-    assert utils.is_in_blacklist('/jobs/42/results', blacklist) is True
-    assert utils.is_in_blacklist('/jobs/42/', blacklist) is False
+    blacklist = convert_endpoints('/jobs/*/results', '/support/*')
+    assert is_in_blacklist('/jobs/42/results', blacklist) is True
+    assert is_in_blacklist('/jobs/42/', blacklist) is False
 
-    assert utils.is_in_blacklist('/support/', blacklist) is True
-    assert utils.is_in_blacklist('/support/tickets/23', blacklist) is True
-    assert utils.is_in_blacklist('/support/admin', blacklist) is True
-    assert utils.is_in_blacklist('/support', blacklist) is False
+    assert is_in_blacklist('/support/', blacklist) is True
+    assert is_in_blacklist('/support/tickets/23', blacklist) is True
+    assert is_in_blacklist('/support/admin', blacklist) is True
+    assert is_in_blacklist('/support', blacklist) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,15 @@
-from howfast_apm.utils import convert_endpoints, is_in_blacklist
+from howfast_apm.utils import compile_endpoints, is_in_blacklist
 
 
 def test_is_blacklist_exact():
     """ The blacklist util should support exact strings matching """
-    blacklist = convert_endpoints('/exact-uri/')
+    blacklist = compile_endpoints('/exact-uri/')
     assert is_in_blacklist('/some-real-uri/', blacklist) is False
     assert is_in_blacklist('/exact-uri/', blacklist) is True
     assert is_in_blacklist('/exact-uri/with-subpath', blacklist) is False
 
     # With multiple patterns
-    multiple_blacklist = convert_endpoints('/exact-uri-1/', '/exact-uri-2/')
+    multiple_blacklist = compile_endpoints('/exact-uri-1/', '/exact-uri-2/')
     assert is_in_blacklist('/exact-uri-1/', multiple_blacklist) is True
     assert is_in_blacklist('/exact-uri-2/', multiple_blacklist) is True
     assert is_in_blacklist('/exact-uri-3/', multiple_blacklist) is False
@@ -17,7 +17,7 @@ def test_is_blacklist_exact():
 
 def test_is_blacklist_glob():
     """ The blacklist util should support shell-like matching """
-    blacklist = convert_endpoints('/jobs/*/results', '/support/*')
+    blacklist = compile_endpoints('/jobs/*/results', '/support/*')
     assert is_in_blacklist('/jobs/42/results', blacklist) is True
     assert is_in_blacklist('/jobs/42/', blacklist) is False
 


### PR DESCRIPTION
Hi @MickaelBergem,

as I was reading through the code, I realized that checking for blacklisted endpoint could be tedious as the list grows.

I tested it

```python
if __name__ == "__main__":
    b = ['/jobs/*/results', '/jobs/*/*/progress', ]
    times = timeit.Timer(functools.partial(is_in_blacklist, '/test', b)).repeat(repeat=3, number=1000)
    print(times)

    b = b + b + b + b + b + b
    b = b + b + b + b + b + b
    b = b + b + b + b + b + b
    b = b + b + b + b + b + b
    b = b + b + b + b + b + b

    times = timeit.Timer(functools.partial(is_in_blacklist, '/test', b)).repeat(repeat=3, number=1000)
    print(times)
```

the result was obvious, the more endpoint you add, the longer it takes:

```
short list: [0.004838313005166128, 0.004496372013818473, 0.004295461985748261]
long list:  [30.687488282012055, 33.16138723300537, 27.81307909899624]
```

with the code from this PR, the result is better even for a short list:

```
short list: [0.001244339015102014, 0.0012035770050715655, 0.0014499509998131543]
long list:  [4.755746807000833, 4.928609041991876, 4.693075067014433]
```

With this PR, you pay the `re.compiile` prize once at the init of `HowFastFlaskMiddleware` - I don't know if it is worth it.