### PR TITLE
Fix/local variable ennd referenced before assignment

### DIFF
--- a/howfast_apm/flask.py
+++ b/howfast_apm/flask.py
@@ -81,7 +81,7 @@ class HowFastFlaskMiddleware(CoreAPM):
             return_value = self.wsgi_app(environ, _start_response_wrapped)
             # Stop the timer as soon as possible to get the best measure of the function's execution time
             end = timer()
-        except Exception:
+        except BaseException:
             # The WSGI app raised an exception, let's still save the point before raising the
             # exception again
             # First, "stop" the timer now to get the good measure of the function's execution time

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -98,6 +98,7 @@ def test_with_exception(HowFastFlaskMiddleware):
     assert point.get('response_status') == "500 INTERNAL SERVER ERROR"
     assert point.get('uri') == "/exception"
 
+
 def test_with_error(HowFastFlaskMiddleware):
     """ The middleware should gracefully handle routes that raise an Error """
     app = create_app()

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -104,8 +104,10 @@ def test_with_error(HowFastFlaskMiddleware):
     middleware = HowFastFlaskMiddleware(app, app_id='some-dsn')
 
     tester = app.test_client()
-    response = tester.get('/error')
-    assert response.status_code == 500
+    with pytest.raises(SystemExit):
+        # Flask will propagate the SystemExit instead of catching it
+        tester.get('/error')
+    # However, the failure should still be logged by the middleware
     assert middleware._save_point.called is True
     assert middleware._save_point.call_count == 1
     point = middleware._save_point.call_args[1]


### PR DESCRIPTION
this fix does not work, I dont understand why

I also tried a simple `except:` with the same result

- 8c6624b : show the same error as in my sentry issue
- 1ef405e : does not work, but fails differently

any idea @MickaelBergem ?

does _not_ fix #14 